### PR TITLE
chore: upgrade Symfony from 7.1 to 7.4 LTS (#455)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,14 @@
     "license": "MIT",
     "type": "novosga-module",
     "autoload": {
-        "psr-4": { "Novosga\\UsersBundle\\": "src/" }
+        "psr-4": {
+            "Novosga\\UsersBundle\\": "src/"
+        }
     },
     "autoload-dev": {
-        "psr-4": { "Novosga\\UsersBundle\\Tests\\": "tests/" }
+        "psr-4": {
+            "Novosga\\UsersBundle\\Tests\\": "tests/"
+        }
     },
     "require": {
         "php": ">=8.2",
@@ -14,9 +18,9 @@
         "novosga/core": "2.3.x-dev",
         "pagerfanta/doctrine-orm-adapter": "*",
         "pagerfanta/pagerfanta": "^4.6",
-        "symfony/framework-bundle": "7.1.*",
-        "symfony/password-hasher": "7.1.*",
-        "symfony/translation": "7.1.*"
+        "symfony/framework-bundle": "7.4.*",
+        "symfony/password-hasher": "7.4.*",
+        "symfony/translation": "7.4.*"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
## Summary

Part of novosga/novosga#455 — main PR: novosga/novosga#495.

Bumps all `symfony/*` constraints from `7.1.*` → `7.4.*` in `composer.json`.

## Test plan

- [x] `composer install` resolves cleanly
- [x] `vendor/bin/phpunit` passes
- [x] `vendor/bin/phpstan` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)