### PR TITLE
chore: upgrade dev tools (phpstan 2, phpunit 11, phpcs 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 .phpcs-cache
+.phpunit.result.cache

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,0 @@
-{"version":1,"defects":[],"times":[]}

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,11 @@
         "symfony/translation": "7.4.*"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.5",
-        "slevomat/coding-standard": "~8.0"
+        "phpstan/phpdoc-parser": "^2.3.2",
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^11.5.55",
+        "slevomat/coding-standard": "^8.28",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         convertDeprecationsToExceptions="false"
+        
 >
     <php>
         <ini name="display_errors" value="1" />
@@ -20,11 +20,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
+    </source>
 
     <extensions>
     </extensions>

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -216,23 +216,21 @@ class DefaultController extends AbstractController
         $lotacoesRemovidas = [];
         if ($form->isSubmitted() && $form->isValid()) {
             try {
-                /** @var int[] */
+                /** @var string[] */
                 $unidadesRemovidas = explode(',', $form->get('lotacoesRemovidas')->getData() ?? '');
 
-                if (is_array($unidadesRemovidas) && count($unidadesRemovidas)) {
-                    foreach ($unidadesRemovidas as $lotacaoId) {
-                        foreach ($entity->getLotacoes() as $lotacao) {
-                            if ($lotacao->getId() === (int) $lotacaoId) {
-                                if (!$isAdmin && !in_array($lotacao->getUnidade(), $unidades)) {
-                                    $error = $translator->trans('error.remove_lotation_permission_denied', [
-                                        '%unidade%' => $lotacao->getUnidade(),
-                                    ], NovosgaUsersBundle::getDomain());
+                foreach ($unidadesRemovidas as $lotacaoId) {
+                    foreach ($entity->getLotacoes() as $lotacao) {
+                        if ($lotacao->getId() === (int) $lotacaoId) {
+                            if (!$isAdmin && !in_array($lotacao->getUnidade(), $unidades)) {
+                                $error = $translator->trans('error.remove_lotation_permission_denied', [
+                                    '%unidade%' => $lotacao->getUnidade(),
+                                ], NovosgaUsersBundle::getDomain());
 
-                                    throw new Exception($error);
-                                }
-                                $lotacoesRemovidas[] = $lotacao;
-                                $entity->getLotacoes()->removeElement($lotacao);
+                                throw new Exception($error);
                             }
+                            $lotacoesRemovidas[] = $lotacao;
+                            $entity->getLotacoes()->removeElement($lotacao);
                         }
                     }
                 }

--- a/tests/Form/UsuarioTypeTest.php
+++ b/tests/Form/UsuarioTypeTest.php
@@ -15,6 +15,7 @@ namespace Novosga\UsersBundle\Tests\Form;
 
 use Novosga\Entity\UsuarioInterface;
 use Novosga\UsersBundle\Form\UsuarioType;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\FormExtensionInterface;
@@ -51,9 +52,7 @@ class UsuarioTypeTest extends TypeTestCase
         $this->assertEquals($formData['email'], $form->get('email')->getData());
     }
 
-    /**
-     * @dataProvider validLoginDataProvider
-     */
+    #[DataProvider('validLoginDataProvider')]
     public function testLoginValidationValidUsernames(string $login, string $message): void
     {
         $formData = $this->buildFormData();
@@ -69,9 +68,7 @@ class UsuarioTypeTest extends TypeTestCase
         $this->assertCount(0, $form->get('login')->getErrors(), $message);
     }
 
-    /**
-     * @dataProvider invalidLoginDataProvider
-     */
+    #[DataProvider('invalidLoginDataProvider')]
     public function testLoginValidationInvalidUsernames(string $login, string $message): void
     {
         $formData = $this->buildFormData();
@@ -186,7 +183,7 @@ class UsuarioTypeTest extends TypeTestCase
     }
 
     /** @return array<array{string, string}> */
-    public function validLoginDataProvider(): array
+    public static function validLoginDataProvider(): array
     {
         return [
             // Valid usernames
@@ -202,7 +199,7 @@ class UsuarioTypeTest extends TypeTestCase
     }
 
     /** @return array<array{string, string}> */
-    public function invalidLoginDataProvider(): array
+    public static function invalidLoginDataProvider(): array
     {
         return [
             // Invalid usernames - too short


### PR DESCRIPTION
Upgrade dev-only dependencies to match the versions used in the main application (novosga/novosga#455):

- `phpstan/phpstan`: `^1.10` → `^2.1`
- `phpstan/phpdoc-parser`: added `^2.3.2`
- `phpunit/phpunit`: `^9.5` → `^11.5.55`
- `slevomat/coding-standard`: `~8.0` → `^8.28`
- `squizlabs/php_codesniffer`: added `^4.0`

Fix PHPStan 2 issues (use `assert()` for type narrowing of `getUser()` calls) and update `phpunit.xml.dist` for PHPUnit 11 compatibility.